### PR TITLE
Use HTTPS for Google Fonts

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -17,7 +17,7 @@
     {{ghost_head}}
 
     {{! Styles & Scripts }}
-    <link href="http://fonts.googleapis.com/css?family=Oswald:700|Lora:400,400italic" rel="stylesheet" type="text/css" />
+    <link href="https://fonts.googleapis.com/css?family=Oswald:700|Lora:400,400italic" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="{{asset "css/poole.css"}}" />
     <link rel="stylesheet" href="{{asset "css/daring.css"}}" />
     <link rel="stylesheet" href="{{asset "css/themes.css"}}" />


### PR DESCRIPTION
Probably the smallest PR ever made :)
When a Ghost blog gets served over HTTPS, this will cause problems in
most browsers because they require all content to be loaded over HTTPS,
including external (for example: Google Fonts) content.

More info: https://support.google.com/chrome/answer/1342714?hl=en
